### PR TITLE
Support user UUID public_id in API responses

### DIFF
--- a/migrations/20250628165500_add_public_id_to_users.js
+++ b/migrations/20250628165500_add_public_id_to_users.js
@@ -1,0 +1,26 @@
+/**
+ * Migration to add public_id UUID column to users
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable("users", function (table) {
+    table
+      .uuid("public_id")
+      .unique()
+      .notNullable()
+      .defaultTo(knex.raw("gen_random_uuid()"));
+    table.index("public_id");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("users", function (table) {
+    table.dropIndex("public_id");
+    table.dropColumn("public_id");
+  });
+};

--- a/schemas/authSchemas.js
+++ b/schemas/authSchemas.js
@@ -5,7 +5,7 @@ const S_USER_RESPONSE = {
   $id: "UserAuthResponse", // ID para referência via $ref
   type: "object",
   properties: {
-    id: { type: "integer", description: "ID do usuário" },
+    id: { type: "string", description: "ID público do usuário" },
     name: { type: "string", description: "Nome do usuário" },
     email: {
       type: "string",

--- a/schemas/userSchemas.js
+++ b/schemas/userSchemas.js
@@ -5,7 +5,7 @@ const S_USER_PROFILE_RESPONSE = {
   $id: "UserProfileResponse",
   type: "object",
   properties: {
-    id: { type: "integer", description: "ID do usuário" },
+    id: { type: "string", description: "ID público do usuário" },
     name: { type: "string", description: "Nome do usuário" },
     email: {
       type: "string",

--- a/services/authService.js
+++ b/services/authService.js
@@ -72,7 +72,7 @@ async function registerUser(fastify, { name, email, password }) {
       role: "user", // Papel padrão
       status: "active", // Status padrão
     })
-    .returning(["id", "name", "email", "role", "refresh_token"]); // Inclui refresh_token para _generateUserTokens
+    .returning(["id", "public_id", "name", "email", "role", "refresh_token"]); // Inclui refresh_token para _generateUserTokens
 
   const freePlan = await knex("plans").where({ name: "Gratuito" }).first();
   if (freePlan) {
@@ -94,7 +94,7 @@ async function registerUser(fastify, { name, email, password }) {
 
   // Retorna apenas os campos seguros do usuário
   const safeUser = {
-    id: newUserFromDB.id,
+    id: newUserFromDB.public_id,
     name: newUserFromDB.name,
     email: newUserFromDB.email,
     role: newUserFromDB.role,
@@ -137,7 +137,7 @@ async function loginUser(fastify, { email, password }) {
   // Gera novos tokens, rotacionando o refresh token (boa prática no login)
   const tokens = await _generateUserTokens(fastify, user, true);
   const userResponse = {
-    id: user.id,
+    id: user.public_id,
     name: user.name,
     email: user.email,
     role: user.role,

--- a/services/userService.js
+++ b/services/userService.js
@@ -4,7 +4,14 @@ async function getUserProfile(fastify, userId) {
   const { knex, log } = fastify;
 
   const user = await knex("users")
-    .select("id", "name", "email", "role", "status", "created_at")
+    .select(
+      "public_id as id",
+      "name",
+      "email",
+      "role",
+      "status",
+      "created_at"
+    )
     .where({ id: userId })
     .first();
 


### PR DESCRIPTION
## Summary
- add migration to add `public_id` uuid column to `users`
- return `public_id` when registering or logging in
- expose public user id in profile service
- adjust user schemas to expect a string id

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68601da41be48321b64b8e16690f5531