### PR TITLE
Switch routes to use public_id identifiers

### DIFF
--- a/migrations/20250628171500_add_public_id_to_products.js
+++ b/migrations/20250628171500_add_public_id_to_products.js
@@ -1,0 +1,26 @@
+/**
+ * Migration to add public_id UUID column to products
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable("products", function (table) {
+    table
+      .uuid("public_id")
+      .unique()
+      .notNullable()
+      .defaultTo(knex.raw("gen_random_uuid()"));
+    table.index("public_id");
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("products", function (table) {
+    table.dropIndex("public_id");
+    table.dropColumn("public_id");
+  });
+};

--- a/routes/companies/clients.js
+++ b/routes/companies/clients.js
@@ -21,9 +21,13 @@ module.exports = async function (fastify, opts) {
         } catch (ownerError) {
           // 2. Se não for o proprietário (o `catch` foi acionado), verifica se há um compartilhamento ativo.
           if (ownerError.statusCode === 403 || ownerError.statusCode === 404) {
+            const companyInternalId = await services.company._resolveCompanyId(
+              knex,
+              companyId
+            );
             const share = await knex("company_shares")
               .where({
-                company_id: companyId,
+                company_id: companyInternalId,
                 shared_with_user_id: userId,
                 status: "active",
               })

--- a/routes/companies/products.js
+++ b/routes/companies/products.js
@@ -24,9 +24,13 @@ module.exports = async function (fastify, opts) {
               ownerError.statusCode === 403 ||
               ownerError.statusCode === 404
             ) {
+              const companyInternalId = await services.company._resolveCompanyId(
+                knex,
+                companyId
+              );
               const share = await knex("company_shares")
                 .where({
-                  company_id: companyId,
+                  company_id: companyInternalId,
                   shared_with_user_id: userId,
                   status: "active",
                 })
@@ -235,7 +239,7 @@ module.exports = async function (fastify, opts) {
         security: [{ bearerAuth: [] }],
         params: {
           type: "object",
-          properties: { companyId: { type: "integer" } },
+          properties: { companyId: { type: "string" } },
           required: ["companyId"],
         },
         response: {

--- a/routes/companies/quotes.js
+++ b/routes/companies/quotes.js
@@ -28,9 +28,13 @@ module.exports = async function (fastify, opts) {
               ownerError.statusCode === 403 ||
               ownerError.statusCode === 404
             ) {
+              const companyInternalId = await services.company._resolveCompanyId(
+                knex,
+                companyId
+              );
               const share = await knex("company_shares")
                 .where({
-                  company_id: companyId,
+                  company_id: companyInternalId,
                   shared_with_user_id: userId,
                   status: "active",
                 })
@@ -258,7 +262,7 @@ module.exports = async function (fastify, opts) {
         security: [{ bearerAuth: [] }],
         params: {
           type: "object",
-          properties: { companyId: { type: "integer" } },
+          properties: { companyId: { type: "string" } },
           required: ["companyId"],
         },
         response: {
@@ -302,7 +306,7 @@ module.exports = async function (fastify, opts) {
         security: [{ bearerAuth: [] }],
         params: {
           type: "object",
-          properties: { companyId: { type: "integer" } },
+          properties: { companyId: { type: "string" } },
           required: ["companyId"],
         },
         querystring: {
@@ -360,7 +364,7 @@ module.exports = async function (fastify, opts) {
         security: [{ bearerAuth: [] }],
         params: {
           type: "object",
-          properties: { companyId: { type: "integer" } },
+          properties: { companyId: { type: "string" } },
           required: ["companyId"],
         },
         response: {

--- a/schemas/clientSchemas.js
+++ b/schemas/clientSchemas.js
@@ -6,7 +6,7 @@ const ClientResponse = {
   type: "object",
   properties: {
     id: { type: "string" },
-    company_id: { type: "integer" },
+    company_id: { type: "string" },
     name: { type: "string" },
     email: { type: ["string", "null"], format: "email" },
     phone_number: { type: ["string", "null"] },

--- a/schemas/productSchemas.js
+++ b/schemas/productSchemas.js
@@ -5,8 +5,8 @@ const S_PRODUCT_RESPONSE = {
   $id: "ProductResponse",
   type: "object",
   properties: {
-    id: { type: "integer", description: "ID do produto" },
-    company_id: { type: "integer", description: "ID da empresa" },
+    id: { type: "string", description: "ID do produto" },
+    company_id: { type: "string", description: "ID da empresa" },
     name: {
       type: "string",
       maxLength: 255,
@@ -172,7 +172,7 @@ const createProductSchema = {
   security: [{ bearerAuth: [] }],
   params: {
     type: "object",
-    properties: { companyId: { type: "integer" } },
+    properties: { companyId: { type: "string" } },
     required: ["companyId"],
   },
   body: { $ref: "ProductCreatePayload#" },
@@ -198,7 +198,7 @@ const listProductsSchema = {
   security: [{ bearerAuth: [] }],
   params: {
     type: "object",
-    properties: { companyId: { type: "integer" } },
+    properties: { companyId: { type: "string" } },
     required: ["companyId"],
   },
   querystring: { $ref: "ProductListQueryString#" },
@@ -237,8 +237,8 @@ const getProductByIdSchema = {
   params: {
     type: "object",
     properties: {
-      companyId: { type: "integer" },
-      productId: { type: "integer" },
+      companyId: { type: "string" },
+      productId: { type: "string" },
     },
     required: ["companyId", "productId"],
   },
@@ -263,8 +263,8 @@ const updateProductSchema = {
   params: {
     type: "object",
     properties: {
-      companyId: { type: "integer" },
-      productId: { type: "integer" },
+      companyId: { type: "string" },
+      productId: { type: "string" },
     },
     required: ["companyId", "productId"],
   },
@@ -292,8 +292,8 @@ const deleteProductSchema = {
   params: {
     type: "object",
     properties: {
-      companyId: { type: "integer" },
-      productId: { type: "integer" },
+      companyId: { type: "string" },
+      productId: { type: "string" },
     },
     required: ["companyId", "productId"],
   },

--- a/schemas/quoteSchemas.js
+++ b/schemas/quoteSchemas.js
@@ -7,7 +7,7 @@ const S_QUOTE_ITEM = {
   properties: {
     id: { type: "integer", description: "ID do item" },
     product_id: {
-      type: ["integer", "null"],
+      type: ["string", "null"],
       description: "ID do produto (se vinculado ao catálogo)",
     },
     description: {
@@ -41,7 +41,7 @@ const S_QUOTE_RESPONSE = {
   type: "object",
   properties: {
     id: { type: "string", description: "ID público do orçamento" },
-    company_id: { type: "integer", description: "ID da empresa" },
+    company_id: { type: "string", description: "ID da empresa" },
     client_id: { type: "string", description: "ID do cliente" },
     created_by_user_id: {
       type: ["integer", "null"],
@@ -216,7 +216,7 @@ const S_QUOTE_CREATE_PAYLOAD = {
         type: "object",
         properties: {
           product_id: {
-            type: ["integer", "null"],
+            type: ["string", "null"],
             description: "ID do produto (opcional)",
           },
           description: {
@@ -286,7 +286,7 @@ const S_QUOTE_UPDATE_PAYLOAD = {
             type: ["integer", "null"],
             description: "ID do item (para atualização)",
           },
-          product_id: { type: ["integer", "null"] },
+          product_id: { type: ["string", "null"] },
           description: { type: "string", minLength: 1 },
           quantity: { type: "number", minimum: 0.01 },
           unit_price_cents: { type: "integer", minimum: 0 },

--- a/services/clientService.js
+++ b/services/clientService.js
@@ -84,6 +84,10 @@ class ClientService {
   }
 
   async listClients(fastify, companyId) {
+    const companyInternalId = await this._resolveCompanyId(
+      fastify.knex,
+      companyId
+    );
     const clients = await fastify
       .knex("clients")
       .where({ company_id: companyInternalId })

--- a/services/companyShareService.js
+++ b/services/companyShareService.js
@@ -1,8 +1,19 @@
 "use strict";
 
 class CompanyShareService {
+  async _resolveCompanyId(knex, identifier) {
+    if (!isNaN(parseInt(identifier))) {
+      return parseInt(identifier);
+    }
+    const row = await knex("companies")
+      .select("id")
+      .where("public_id", identifier)
+      .first();
+    return row ? row.id : null;
+  }
   async createShare(fastify, owner, companyId, recipientEmail, permissions) {
     const { knex, log, services } = fastify;
+    const companyInternalId = await this._resolveCompanyId(knex, companyId);
     const { permission: PermissionService } = services;
 
     if (owner.email === recipientEmail) {
@@ -23,7 +34,7 @@ class CompanyShareService {
     }
 
     const existingShare = await knex("company_shares")
-      .where({ company_id: companyId, shared_with_user_id: recipient.id })
+      .where({ company_id: companyInternalId, shared_with_user_id: recipient.id })
       .first();
     if (existingShare) {
       const error = new Error(
@@ -40,7 +51,7 @@ class CompanyShareService {
     );
 
     const ownerShareCountResult = await knex("company_shares")
-      .where({ company_id: companyId })
+      .where({ company_id: companyInternalId })
       .count("id as total")
       .first();
     if (
@@ -76,7 +87,7 @@ class CompanyShareService {
     }
 
     const shareToInsert = {
-      company_id: companyId,
+      company_id: companyInternalId,
       shared_with_user_id: recipient.id,
       shared_by_user_id: owner.id,
       permissions: permissions || {},
@@ -103,10 +114,14 @@ class CompanyShareService {
   }
 
   async listShares(fastify, companyId) {
+    const companyInternalId = await this._resolveCompanyId(
+      fastify.knex,
+      companyId
+    );
     return fastify
       .knex("company_shares as cs")
       .join("users as u", "cs.shared_with_user_id", "u.id")
-      .where("cs.company_id", companyId)
+      .where("cs.company_id", companyInternalId)
       .select(
         "cs.id as share_id",
         "u.id as user_id",
@@ -119,10 +134,14 @@ class CompanyShareService {
   }
 
   async deleteShare(fastify, companyId, sharedUserId) {
+    const companyInternalId = await this._resolveCompanyId(
+      fastify.knex,
+      companyId
+    );
     const result = await fastify
       .knex("company_shares")
       .where({
-        company_id: companyId,
+        company_id: companyInternalId,
         shared_with_user_id: sharedUserId, // Corrigido para a nova coluna
       })
       .del();


### PR DESCRIPTION
## Summary
- add migration for product public_id
- resolve public IDs in product service and company shares
- map public_id responses for products
- accept public_id params in schemas and routes
- convert share checks to use internal IDs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68604c2cd03c832186b99b456ad88aca