### PR TITLE
Fix quotes routes to output UUIDs

### DIFF
--- a/schemas/quoteSchemas.js
+++ b/schemas/quoteSchemas.js
@@ -44,7 +44,7 @@ const S_QUOTE_RESPONSE = {
     company_id: { type: "string", description: "ID da empresa" },
     client_id: { type: "string", description: "ID do cliente" },
     created_by_user_id: {
-      type: ["integer", "null"],
+      type: ["string", "null"],
       description: "ID do usuário que criou",
     },
     quote_number: {


### PR DESCRIPTION
## Summary
- ensure quote responses return UUIDs for company, client and user
- update query joins to fetch related public IDs
- adjust API schema for created_by_user_id field

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862d42506748321ab28c3186dc32e6f