### PR TITLE
feat: add quote pdf data endpoint

### DIFF
--- a/routes/companies/quotes.js
+++ b/routes/companies/quotes.js
@@ -286,6 +286,24 @@ module.exports = async function (fastify, opts) {
     }
   );
 
+  // GET /api/companies/:companyId/quotes/:quoteId/pdf-data (OPERAÇÃO DE LEITURA)
+  fastify.get(
+    "/:companyId/quotes/:quoteId/pdf-data",
+    { schema: schemas.getQuotePdfDataSchema, ...readPreHandler },
+    async (request, reply) => {
+      const pdfData = await handleServiceCall(
+        reply,
+        services.quote.getQuotePdfData.bind(services.quote),
+        fastify, // 1º: fastify instance
+        request.params.companyId, // 2º: companyId
+        request.params.quoteId // 3º: quoteId
+      );
+      if (pdfData) {
+        reply.send(pdfData);
+      }
+    }
+  );
+
   // PUT /api/companies/:companyId/quotes/:quoteId (OPERAÇÃO DE ESCRITA)
   fastify.put(
     "/:companyId/quotes/:quoteId",

--- a/schemas/quoteSchemas.js
+++ b/schemas/quoteSchemas.js
@@ -389,6 +389,32 @@ const getQuoteByIdSchema = {
   },
 };
 
+// GET /api/companies/:companyId/quotes/:quoteId/pdf-data
+const getQuotePdfDataSchema = {
+  description: "Retorna dados do orçamento formatados para geração de PDF.",
+  tags: ["Orçamentos"],
+  summary: "Dados para PDF do Orçamento",
+  security: [{ bearerAuth: [] }],
+  params: {
+    type: "object",
+    properties: { companyId: { type: "string" }, quoteId: { type: "string" } },
+    required: ["companyId", "quoteId"],
+  },
+  response: {
+    200: {
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        data: { type: "object" },
+      },
+    },
+    401: { $ref: "ErrorResponse#" },
+    403: { $ref: "ErrorResponse#" },
+    404: { $ref: "ErrorResponse#" },
+    500: { $ref: "ErrorResponse#" },
+  },
+};
+
 // PUT /api/companies/:companyId/quotes/:quoteId
 const updateQuoteSchema = {
   description: "Atualiza um orçamento específico.",
@@ -542,6 +568,7 @@ module.exports = {
   createQuoteSchema,
   listQuotesSchema,
   getQuoteByIdSchema,
+  getQuotePdfDataSchema,
   updateQuoteSchema,
   deleteQuoteSchema,
   updateQuoteStatusSchema,

--- a/schemas/quoteSchemas.js
+++ b/schemas/quoteSchemas.js
@@ -403,9 +403,79 @@ const getQuotePdfDataSchema = {
   response: {
     200: {
       type: "object",
+      required: ["title", "data"],
       properties: {
         title: { type: "string" },
-        data: { type: "object" },
+        data: {
+          type: "object",
+          required: ["logo", "watermark", "budget"],
+          properties: {
+            logo: {
+              type: "object",
+              required: ["url"],
+              properties: {
+                url: { type: "string", format: "uri" },
+              },
+            },
+            watermark: {
+              type: "object",
+              required: ["type"],
+              properties: {
+                type: { type: "string" },
+                logo: {
+                  type: "object",
+                  required: ["url"],
+                  properties: {
+                    url: { type: "string", format: "uri" },
+                  },
+                },
+              },
+            },
+            budget: {
+              type: "object",
+              required: ["number", "validUntil", "status", "company", "client", "items"],
+              properties: {
+                number: { type: "string" },
+                validUntil: { type: "string" },
+                status: { type: "string" },
+                company: {
+                  type: "object",
+                  required: ["name"],
+                  properties: {
+                    name: { type: "string" },
+                    cnpj: { type: ["string", "null"] },
+                    address: { type: ["string", "null"] },
+                    phone: { type: ["string", "null"] },
+                    email: { type: ["string", "null"] },
+                  },
+                },
+                client: {
+                  type: "object",
+                  required: ["name"],
+                  properties: {
+                    name: { type: "string" },
+                    phone: { type: ["string", "null"] },
+                  },
+                },
+                items: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    required: ["description", "quantity", "unitPrice"],
+                    properties: {
+                      description: { type: "string" },
+                      quantity: { type: "number" },
+                      unitPrice: { type: "number" },
+                    },
+                  },
+                },
+                discount: { type: "number" },
+                notes: { type: ["string", "null"] },
+                terms: { type: ["string", "null"] },
+              },
+            },
+          },
+        },
       },
     },
     401: { $ref: "ErrorResponse#" },


### PR DESCRIPTION
## Summary
- add service method to gather essential quote info for PDF generation
- expose GET `/api/companies/:companyId/quotes/:quoteId/pdf-data`
- document schema for PDF data endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a73360d098832192ac8f3a1f5e15e9