### PR TITLE
Fix companyId type for share routes

### DIFF
--- a/api.json
+++ b/api.json
@@ -2269,14 +2269,14 @@
             }
           }
         },
-        "parameters": [
-          {
-            "schema": { "type": "integer" },
-            "in": "path",
-            "name": "companyId",
-            "required": true
-          }
-        ],
+          "parameters": [
+            {
+              "schema": { "type": "string" },
+              "in": "path",
+              "name": "companyId",
+              "required": true
+            }
+          ],
         "security": [{ "bearerAuth": [] }],
         "responses": {
           "201": {
@@ -2317,14 +2317,14 @@
         "summary": "Listar Compartilhamentos",
         "tags": ["Empresas - Compartilhamento"],
         "description": "Lista os compartilhamentos de uma empresa.",
-        "parameters": [
-          {
-            "schema": { "type": "integer" },
-            "in": "path",
-            "name": "companyId",
-            "required": true
-          }
-        ],
+          "parameters": [
+            {
+              "schema": { "type": "string" },
+              "in": "path",
+              "name": "companyId",
+              "required": true
+            }
+          ],
         "security": [{ "bearerAuth": [] }],
         "responses": {
           "200": {
@@ -2362,20 +2362,20 @@
         "summary": "Remover Compartilhamento",
         "tags": ["Empresas - Compartilhamento"],
         "description": "Remove o compartilhamento de uma empresa com um usuário.",
-        "parameters": [
-          {
-            "schema": { "type": "integer" },
-            "in": "path",
-            "name": "companyId",
-            "required": true
-          },
-          {
-            "schema": { "type": "integer" },
-            "in": "path",
-            "name": "userId",
-            "required": true
-          }
-        ],
+          "parameters": [
+            {
+              "schema": { "type": "string" },
+              "in": "path",
+              "name": "companyId",
+              "required": true
+            },
+            {
+              "schema": { "type": "integer" },
+              "in": "path",
+              "name": "userId",
+              "required": true
+            }
+          ],
         "security": [{ "bearerAuth": [] }],
         "responses": {
           "200": {

--- a/schemas/companyShareSchemas.js
+++ b/schemas/companyShareSchemas.js
@@ -50,7 +50,7 @@ const createShareSchema = {
   params: {
     // <--- ADICIONADO AQUI
     type: "object",
-    properties: { companyId: { type: "integer" } },
+    properties: { companyId: { type: "string" } },
     required: ["companyId"],
   },
   body: { $ref: "CompanySharePayload#" },
@@ -71,7 +71,7 @@ const listSharesSchema = {
   params: {
     // <--- ADICIONADO AQUI
     type: "object",
-    properties: { companyId: { type: "integer" } },
+    properties: { companyId: { type: "string" } },
     required: ["companyId"],
   },
   response: {
@@ -91,7 +91,7 @@ const deleteShareSchema = {
     // <--- ADICIONADO AQUI
     type: "object",
     properties: {
-      companyId: { type: "integer" },
+      companyId: { type: "string" },
       userId: { type: "integer" },
     },
     required: ["companyId", "userId"],


### PR DESCRIPTION
## Summary
- allow string companyId in company share schemas
- update OpenAPI docs for share endpoints

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c8d146148321956e3ee881ea61da